### PR TITLE
Rewrite Old Man

### DIFF
--- a/2099-01-01-oldman.md
+++ b/2099-01-01-oldman.md
@@ -6,12 +6,12 @@ layout: post
 ---
 
 The Old Man glitch is a programming error in Pokemon Red and Blue that allows
-the player to encounter the glitch Pokemon 'MissingNo' (short for Missing
+the player to encounter the glitch Pokemon 'MissingNo.' (short for Missing
 Number); as well as  a series of other glitch Pokémon dubbed 'name data
 Pokémon'. The name of the glitch comes from the first step needed to perform
 this glitch; in particular,  you must first talk to an 'Old Man' who teaches
 you how to catch a Pokemon near the beginning of the game. After talking to the
-old man, it is possible to encounter corrupted Pokemon the wild. 
+Old Man, it is possible to encounter corrupted Pokemon the wild. 
 
 If performed correctly, you should encounter 'MissingNo.', whose sprite looks
 like the following: 
@@ -38,7 +38,7 @@ involving memory errors.
 
 The following are the in-game steps you need to perform to trigger the bug. 
 
-  1.  Set up the trainer name with  particular characters in particular
+  1.  Set up the trainer name with particular characters in particular
       positions.
   1.  Talk to the Old Man in Viridian City (i.e., the man that shows you how to
       catch Pokemon). Say 'no' to his question and watch his demonstration.
@@ -52,8 +52,8 @@ repo](https://github.com/pret/pokered).
 
 ### How Wild Pokemon Encounters Work 
 
-Pokemon games have two main types of areas, routes and towns. Towns contain
-buildings such as gyms, marts, and Pokemon centers, whereas routes contain
+Pokemon games have two main types of areas: routes and towns. Towns contain
+buildings such as gyms, marts, and Pokemon Centers, whereas routes contain
 trainers you can fight and wild Pokemon you can catch. When you enter a route,
 the engine will load a table that defines the set of wild Pokemon available on
 that route.  The assembly code for loading this data looks like this:
@@ -85,24 +85,24 @@ in the to the **encounters table** whenever the player enters a route.
 The first byte in the encounters table denotes the rate of grass encounters
 (25% for Route 1), the next 20 bytes denote the different Pokemon that may be
 encountered in the Route 1 grass. Specifically, one byte is used to define the
-Pokemon's level and the following byte is used to define the Pokemon type.  The
-encounter rate and Pokemon for water tiles is usually defined immediately
-following the grass encounter day, but Route 1 does not have any water so the
-water encounter rate is set to `0x0` and no water Pokemon are defined.
+Pokemon's level and the following byte is used to define the Pokemon's encounter
+type.  The encounter rate and Pokemon for water tiles is usually defined 
+immediately following the grass encounter data, but Route 1 does not have any water
+so the water encounter rate is set to `0x0` and no water encounter Pokemon are defined.
 
 When you walk into a new location, the Pokemon data gets loaded in via a call
 to `LoadWildData`. In this function, the engine checks if the `NoGrassData`
 flag is set. No cities or towns have grass Pokemon encounters, so the flag is
 set for those locations. If `NoGrassData` is set, the game will not load grass
-Pokemon data; **importantly, this also means that the previously loaded grass
-Pokemon data remains in memory.** In other words, whenever you are in a town,
+encounter Pokemon data; **importantly, this also means that the previously loaded grass
+encounter Pokemon data remains in memory.** In other words, whenever you are in a town,
 the Pokemon that would appear in grass, if there were any, would be the Pokemon
 that were in the last route that you visited.
 
 ![](https://raw.githubusercontent.com/rjwalls/CS4401-notes/master/assets/old-man/route1mons.gif)
 
 We can make this behavior more concrete with the following example: when
-walking between Palette Town and Route 1, as we step onto Route 1, the
+walking between Pallet Town and Route 1, as we step onto Route 1, the
 `Route1Mons` is loaded into memory starting at  address `0xd887` (remember this
 address as it is important later); We refer to this region of memory as the
 *loaded encounters table*.    Specifically, the byte at address `0xd887` is
@@ -118,7 +118,7 @@ values they had when `Route1Mons` was loaded.
 Our objective, as the player, is to get values that we control loaded into the
 encounters table. If we can control the memory of the loaded encounter tables,
 then we can make MissingNo one of the possible encounters. But first we need
-to get an old man to teach us how to fight.
+to get the Old Man to teach us how to fight.
 
 ### Old Man Battle
 
@@ -127,14 +127,14 @@ a Non-Player Character (NPC) named 'Old Man' who will teach you how to catch a
 Pokemon. This tutorial is meant for first-timers who don't know the mechanics
 of the game, but you may talk to him as many times as you would like throughout
 your adventure. If you let him teach you, the game immediately starts a battle
-between the old man and a weedle (a grass type Pokemon). 
+between the Old Man and a Weedle (a grass-encounter Pokemon). 
 
 ![Old Man Shows You How To Catch Pokemon](https://raw.githubusercontent.com/rjwalls/CS4401-notes/master/assets/old-man/oldmanquestion.gif)
 
 When the game simulates this battle, it needs to display the name 'OLD MAN'
 instead of displaying your trainer's name. To achieve this, the game engine
 first temporarily copies the player's name to new location in memory. The
-engine then overwrites the memory previously used for the players name with the
+engine then overwrites the memory previously used for the player's name with the
 text 'OLD MAN'. Once the battle is over, the engine copies the player's name
 back to the original location in memory, but the copy of the name remains. 
 
@@ -148,10 +148,10 @@ loaded encounters table (i.e., the memory starting at address `0xd887`). Thus,
 when the Old Man battle finishes, the memory used for the encounters table is
 now populated with the player's name. In other words, we now have control over
 the values in the encounters table. By setting the player name appropriately,
-we can cause MissingNo (and other Pokemon) to become a possible grass
+we can cause MissingNo. (and other Pokemon) to become a possible grass
 encounter.
 
-Here is a layout of the encounter table after battling the old man. 
+Here is a layout of the encounter table after battling the Old Man. 
 
 | Address | d887                 | d888    | d889      | d88a    | d88b      | d88c    | d88d      | d88e    | d88f      |
 | ------- | -------------------- | ------- | --------- | ------- | --------- | ------- | --------- | ------- | --------- | 
@@ -235,15 +235,15 @@ As described previously, When the battle is over, the player name is copied
 back into `wPlayerName`, but is still stored at `wGrassRate` as well.
 
 
-### The Last Step: Encountering MissingNo
+### The Last Step: Encountering MissingNo.
 
 After the Old Man battle, our trainer name is loaded into the encounters table
-in the region reserved for grass Pokemon, i.e., we control some of the grass
-encounters.  
+in the region reserved for grass encounter Pokemon, i.e., we control some of 
+the grass encounters.  
 
 The final step is to trigger a battle while using our manipulated encounters
 table. Battles typically only occur on routes and we are in a town, but if we
-enter a new route the encounters table will be loaded with the encounter
+enter a new route, the encounters table will be loaded with the encounter
 information for that route, overwriting our manipulated encounters table. Thus,
 we have to figure out how to trigger a wild Pokemon encounter without entering
 a location that will cause a new encounters table to be loaded. 
@@ -252,7 +252,7 @@ The solution is to fly to Cinnabar Island without leaving Viridian City. This
 will leave the manipulated encounters table intact, with the exception that the
 grass encounter rate will be set to 0x0---recall from above that the grass
 encounter rate is set to 0x0 when entering towns. At first a zero encounter
-rate seems like a showstopper: all of our manipulated encounters are grass
+rate seems like a showstopper; all of our manipulated encounters are grass
 Pokemon and, thus, with an encounter rate of 0 they should never appear.  
 Fortunately, Pokemon's developers made a mistake when programming some of the 
 shore blocks in Cinnabar Island.  
@@ -276,11 +276,11 @@ the game will use our tampered-with grass Pokemon encounters! Success!
 Above we described how to control the memory used to determine Pokemon
 encounters and how to exploit a programming error to get the game to use these
 manipulated bytes. Finally, by setting these bytes to specially crafted values
-(via the player name) we can cause MissingNo to appear.  
+(via the player name) we can cause MissingNo. to appear.  
 
 ### As an Aside
 
-It is interesting to see  how similar the implementation of CopyData is to the
+It is interesting to see how similar the implementation of CopyData is to the
 Stdlib's
 [memcpy](https://github.com/gcc-mirror/gcc/blob/master/libgcc/memcpy.c)
 function

--- a/2099-01-01-oldman.md
+++ b/2099-01-01-oldman.md
@@ -6,7 +6,7 @@ layout: post
 ---
 
 The Old Man glitch is a programming error in Pokemon Red and Blue that allows
-the player to encounter the glitch Pokemon 'MissingNo.' (short for Missing
+the player to encounter the glitch Pokemon 'MissingNo' (short for Missing
 Number); as well as  a series of other glitch Pokémon dubbed 'name data
 Pokémon'. The name of the glitch comes from the first step needed to perform
 this glitch; in particular,  you must first talk to an 'Old Man' who teaches

--- a/2099-01-01-oldman.md
+++ b/2099-01-01-oldman.md
@@ -6,7 +6,7 @@ layout: post
 ---
 
 The Old Man glitch is a programming error in Pokemon Red and Blue that allows
-the player to encounter the glitch Pokemon 'MissingNo' (short for Missing
+the player to encounter the glitch Pokemon 'MissingNo.' (short for Missing
 Number); as well as  a series of other glitch Pokémon dubbed 'name data
 Pokémon'. The name of the glitch comes from the first step needed to perform
 this glitch; in particular,  you must first talk to an 'Old Man' who teaches

--- a/2099-01-01-oldman.md
+++ b/2099-01-01-oldman.md
@@ -207,7 +207,7 @@ call CopyData
 ```
 
 To understand the flow of data in this section we need to clarify some variable
-names. `wPlayerName` is the byte address of your trainers name. `wGrassRate` is
+names. `wPlayerName` is the byte address of your trainer's name. `wGrassRate` is
 the address of the grass rate value.  `NAME_LENGTH` is a constant defined to be
 equal to 11, although player names are limited to 7 characters.
 


### PR DESCRIPTION
Made capitalization consistent with Old Man as well as Pokemon names
Fixed some small grammatical errors / typos
Referred to "Grass Type" Pokemon as "Grass-Encounter Type" to avoid confusion with hardcore fans of the game


